### PR TITLE
feat: support progress bars on pages

### DIFF
--- a/flexoki-theme.css
+++ b/flexoki-theme.css
@@ -1029,17 +1029,27 @@ progress {
     vertical-align: middle;
     border-radius: var(--flexoki-radius-md);
     height: var(--flexoki-text-lg);
-    width: 100px;
+  width: 15%;
+  min-width: 50px;
+  max-width: 100px;
     border: 1px solid var(--flexoki-border);
     overflow: hidden;
 }
   
 progress::-webkit-progress-bar {
-    background: var(--flexoki-background-elevated-secondary);
+  background: var(--flexoki-background-elevated-secondary);
 }
-  
+
+progress::-moz-progress-bar {
+  background: var(--flexoki-background-elevated-secondary);
+}
+
 progress::-webkit-progress-value {
-    background: var(--flexoki-blue);
+  background: var(--flexoki-blue);
+}
+
+progress::-moz-progress-value {
+  background: var(--flexoki-blue);
 }
 
 /* =============================================== */
@@ -1314,3 +1324,4 @@ html[data-theme=dark] {
         /* Inherit light theme variables when system is in light mode */
     }
 }
+


### PR DESCRIPTION
Thank you very much for the awesome theme. Just a small addition for elements like `[:progress {:max 97 :value 26}]` that have not yet been covered by the theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced appearance of the native HTML progress bar to better align with the theme, including improved colors, borders, and rounded corners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->